### PR TITLE
bumping to node 18.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2022-2023 Open Text.
+    Copyright 2022-2024 Open Text.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@
     </developers>
 
     <properties>
-        <copyrightYear>2023</copyrightYear>
+        <copyrightYear>2024</copyrightYear>
         <copyrightNotice>Copyright ${project.inceptionYear}-${copyrightYear} Open Text.</copyrightNotice>
         <dockerHubOrganization>uxaspects</dockerHubOrganization>
         <dockerUXAspectsOrg>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerUXAspectsOrg>

--- a/release-notes-1.3.0.md
+++ b/release-notes-1.3.0.md
@@ -1,8 +1,6 @@
-!not-ready-for-release!
-
 #### Version Number
 ${version-number}
 
 #### New Features
 
-#### Known Issues
+- Bumping to Node 18.20

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2022-2023 Open Text.
+# Copyright 2022-2024 Open Text.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -34,12 +34,12 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | \
     tee /etc/apt/sources.list.d/yarn.list && \
     apt update && apt install yarn
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-    apt-key add - && \
-    echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | \
-    tee /etc/apt/sources.list.d/docker.list
+# RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+#     apt-key add - && \
+#     echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | \
+#     tee /etc/apt/sources.list.d/docker.list
 
-# RUN apt update
+RUN apt update
 
 #
 # Install Cypress Dependencies (https://docs.cypress.io/guides/guides/continuous-integration.html#Dependencies)

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -49,4 +49,4 @@ RUN apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 
 #
 # Install Docker for Loki visual regression testing and dependencies required for Nx and build tooling
 #
-RUN apt install -y docker-ce docker-ce-cli containerd.io build-essential
+# RUN apt install -y docker-ce docker-ce-cli containerd.io build-essential

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -49,4 +49,8 @@ RUN apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 
 #
 # Install Docker for Loki visual regression testing and dependencies required for Nx and build tooling
 #
+RUN apt install -y docker-ce
+RUN apt install -y docker-ce-cli
+RUN apt install -y containerd.io
+RUN apt install -y build-essential
 # RUN apt install -y docker-ce docker-ce-cli containerd.io build-essential

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -35,11 +35,11 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | \
     apt update && apt install yarn
 
 # Add Docker's official GPG key:
-RUN apt-get update
-RUN apt-get install ca-certificates curl
-RUN install -m 0755 -d /etc/apt/keyrings
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
-RUN chmod a+r /etc/apt/keyrings/docker.asc
+RUN apt-get update && \
+    apt-get install ca-certificates curl && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc
     
 # Add the repository to Apt sources:
 RUN echo \
@@ -48,6 +48,7 @@ RUN echo \
     tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 RUN apt-get update
+
 #
 # Install Cypress Dependencies (https://docs.cypress.io/guides/guides/continuous-integration.html#Dependencies)
 #
@@ -56,8 +57,4 @@ RUN apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 
 #
 # Install Docker for Loki visual regression testing and dependencies required for Nx and build tooling
 #
-RUN apt install -y docker-ce
-RUN apt install -y docker-ce-cli
-RUN apt install -y containerd.io
-RUN apt install -y build-essential
-# RUN apt install -y docker-ce docker-ce-cli containerd.io build-essential
+RUN apt install -y docker-ce docker-ce-cli containerd.io build-essential

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
     echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | \
     tee /etc/apt/sources.list.d/docker.list
 
-RUN apt update
+# RUN apt update
 
 #
 # Install Cypress Dependencies (https://docs.cypress.io/guides/guides/continuous-integration.html#Dependencies)

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -34,13 +34,20 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | \
     tee /etc/apt/sources.list.d/yarn.list && \
     apt update && apt install yarn
 
-# RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-#     apt-key add - && \
-#     echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | \
-#     tee /etc/apt/sources.list.d/docker.list
+# Add Docker's official GPG key:
+RUN apt-get update && \
+    apt-get install ca-certificates curl && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc
+    
+# Add the repository to Apt sources:
+RUN echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-RUN apt update
-
+RUN apt-get update
 #
 # Install Cypress Dependencies (https://docs.cypress.io/guides/guides/continuous-integration.html#Dependencies)
 #

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -35,15 +35,15 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | \
     apt update && apt install yarn
 
 # Add Docker's official GPG key:
-RUN apt-get update && \
-    apt-get install ca-certificates curl && \
-    install -m 0755 -d /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
-    chmod a+r /etc/apt/keyrings/docker.asc
+RUN apt-get update
+RUN apt-get install ca-certificates curl
+RUN install -m 0755 -d /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+RUN chmod a+r /etc/apt/keyrings/docker.asc
     
 # Add the repository to Apt sources:
 RUN echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
     tee /etc/apt/sources.list.d/docker.list > /dev/null
 


### PR DESCRIPTION
- Updating Node version to 18.20 (there were no actual change required for this as it pull the latest version of 18.x as part of the build)
- Updating dockerfile to fix the build
- Updating copyright years

Required for https://github.houston.softwaregrp.net/Inner-Source-Incubating/ux-aspects-universal/pull/2400