### PR TITLE
bumping node version to 18.20.4

### DIFF
--- a/release-notes-1.4.0.md
+++ b/release-notes-1.4.0.md
@@ -1,8 +1,7 @@
-!not-ready-for-release!
 
 #### Version Number
 ${version-number}
 
 #### New Features
 
-#### Known Issues
+- Node 18.20.4


### PR DESCRIPTION
Bumping node version to 18.20.4 - this is required for Angular 18. No changes required as upon release the latest version of Node 18 will be pulled.